### PR TITLE
Only roles with right permission can change tree order and publish posts

### DIFF
--- a/index.php
+++ b/index.php
@@ -68,7 +68,9 @@ add_action('wp_ajax_cms_tpv_add_page', 'cms_tpv_add_page');
 add_action('wp_ajax_cms_tpv_add_pages', 'cms_tpv_add_pages');
 
 // activation
+define( "CMS_TPV_MOVE_PERMISSION", "move_cms_tree_view_page");
 register_activation_hook( WP_PLUGIN_DIR . "/cms-tree-page-view/index.php" , 'cms_tpv_install' );
+register_uninstall_hook( WP_PLUGIN_DIR . "/cms-tree-page-view/index.php" , 'cms_tpv_uninstall' );
 
 // To test activation hook, uncomment function below
 // cms_tpv_install();

--- a/scripts/cms_tree_page_view.js
+++ b/scripts/cms_tree_page_view.js
@@ -199,7 +199,7 @@ jQuery(function($) {
 	});
 
 	treeOptions = {
-		plugins: ["themes","json_data","cookies","search","dnd", "types"],
+		plugins: ["themes","json_data","cookies","search",CMS_TPV_CAN_DND, "types"],
 		core: {
 			"html_titles": true
 		},


### PR DESCRIPTION
Fixes:
- only roles Admin and Editor can change tree order. Author, Contributor and any role which have unset custom 'move_cms_tree_view_page' capability cant change tree order. Plugins sets 'move_cms_tree_view_page' capability as default for Admin and Editor)
- only roles with permission 'publish_posts' can publish posts and pages from the tree menu
