### PR TITLE
Fix assignement by reference standards violation

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1927,7 +1927,7 @@ function cms_tpv_add_caps_to_role( $role, $caps ) {
 	global $wp_roles;
 
 	if ( $wp_roles->is_role( $role ) ) {
-		$role =& get_role( $role );
+		$role = get_role( $role );
 		foreach ( $caps as $cap )
 			$role->add_cap( $cap );
 	}
@@ -1941,7 +1941,7 @@ function cms_tpv_remove_caps_from_role( $role, $caps ) {
 	global $wp_roles;
 
 	if ( $wp_roles->is_role( $role ) ) {
-		$role =& get_role( $role );
+		$role = get_role( $role );
 		foreach ( $caps as $cap )
 			$role->remove_cap( $cap );
 	}


### PR DESCRIPTION
Currently, when using this plugin on server with strict standards enabled and/or php 5.5 (or newer) active, logs fill with errors like:

```
Strict Standards: Only variables should be assigned by reference in /sites/hakger.pl/wp-content/plugins/cms-tree-page-view/functions.php on line 1930
```

Since function `get_role` is not defined as returning references, it is safe to simply remove reference operator from assignment.

This problem is/was mentioned here:
http://eskapism.se/wordpress/cms-tree-page-view/comment-page-4/#comment-99867
and here:
https://wordpress.org/support/topic/strict-standards-only-variables-should-be-assigned-by-reference-1

This fix was tested to work with no visible performance degradation on server with error reporting disabled for strict sandards as well as actually fixed logged/displayed errors on servers having strict error enabled :smile: